### PR TITLE
Fix up the active tab highlight

### DIFF
--- a/RedGate.SSC.Windows.Web.Assets/directives/menu-item.js
+++ b/RedGate.SSC.Windows.Web.Assets/directives/menu-item.js
@@ -10,7 +10,7 @@ function menuItem($rootScope, $location) {
     link: function(scope, element, attrs) {
       var path = element.find('a').attr('href');
       $rootScope.$on('$locationChangeStart', function(event, next, current) {
-        element.toggleClass('is-active', path === $location.path());
+        element.toggleClass('is-active', path.slice(1, path.length) === $location.path());
       });
     }
   };

--- a/RedGate.SSC.Windows.Web.Assets/dist/combined.js
+++ b/RedGate.SSC.Windows.Web.Assets/dist/combined.js
@@ -23193,7 +23193,7 @@ function menuItem($rootScope, $location) {
     link: function(scope, element, attrs) {
       var path = element.find('a').attr('href');
       $rootScope.$on('$locationChangeStart', function(event, next, current) {
-        element.toggleClass('is-active', path === $location.path());
+        element.toggleClass('is-active', path.slice(1, path.length) === $location.path());
       });
     }
   };


### PR DESCRIPTION
When we moved from push state to '#/foo' url styles, this directive stopped working.

Not sure what best solution is but this seems okay-ish.
